### PR TITLE
Do not apply the React plugin by default

### DIFF
--- a/seskar/seskar-gradle-plugin/src/main/kotlin/seskar/gradle/plugin/SeskarGradleSubplugin.kt
+++ b/seskar/seskar-gradle-plugin/src/main/kotlin/seskar/gradle/plugin/SeskarGradleSubplugin.kt
@@ -8,13 +8,16 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
-private val SESKAR_COMPILER_PLUGIN_ID = "io.github.turansky.seskar"
+private const val SESKAR_COMPILER_PLUGIN_ID = "io.github.turansky.seskar"
+private const val SESKAR_REACT = "seskar.react"
 
 class SeskarGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         super.apply(target)
 
-        target.plugins.apply(SeskarReactPlugin::class)
+        if (target.findProperty(SESKAR_REACT) != "false") {
+            target.plugins.apply(SeskarReactPlugin::class)
+        }
     }
 
     override fun isApplicable(


### PR DESCRIPTION
The React plugin simply injects the `seskar-react` dependency.  
However, that dependency is best provided manually, as not all projects will use React, and not all projects will have `jsMainImplementation` available.

Note that for this reason I had to manually add the dependency to some of the test projects.