### PR TITLE
Adding internal components to lazy component

### DIFF
--- a/tests/react-lazy-components/header/src/jsMain/kotlin/com/example/header/Header.kt
+++ b/tests/react-lazy-components/header/src/jsMain/kotlin/com/example/header/Header.kt
@@ -8,5 +8,7 @@ import react.dom.html.ReactHTML.div
 val Header = FC {
     div {
         +"Header"
+
+        HeaderContent()
     }
 }

--- a/tests/react-lazy-components/header/src/jsMain/kotlin/com/example/header/HeaderContent.kt
+++ b/tests/react-lazy-components/header/src/jsMain/kotlin/com/example/header/HeaderContent.kt
@@ -1,0 +1,18 @@
+package com.example.header
+
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.span
+
+internal external interface HeaderContentProps : Props
+
+/** */
+internal val HeaderContent = FC<HeaderContentProps> {
+    div {
+        +"Header Content"
+        span {
+            +"SUB CONTENT"
+        }
+    }
+}


### PR DESCRIPTION
When trying out the Lazy components, a common use case might be to build a lazy component out of other internal components.

Expected behaviour:
The Header.js file gets exported and the HeaderContent is also lazyily loaded.

Current behaviour:
No Header.js file is getting exported. Only Footer and Content are getting lazy loaded (first lazy file is content, the second the footer)
![grafik](https://github.com/user-attachments/assets/e342ea7d-b845-42f0-8655-72a6c2ba060a)
